### PR TITLE
Fix typo

### DIFF
--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -44,37 +44,37 @@ Use **Errands** to configure the BOSH Errands used by a9s PostgreSQL for PCF. Fo
 
 ### Post-Deploy Errands
 
- * **Run BOSH Configurator**: 
-	This errand configures a9s BOSH for PCF so that it can provision PostgreSQL
-	service instances. When enabled, this errand uploads the required
-	stemcells in the BOSH release. Disabling this errand may speed up the
-	deployment of all tiles.
+ * **Run BOSH Configurator**:
+	This errand configures **a9s BOSH for PCF** so that it can provision PostgreSQL
+	service instances. When enabled, this errand uploads the required releases in
+  the a9s BOSH Director. Disabling this errand may speed up the deployment of
+  all tiles.
 
 	<p class="note"><strong>Note</strong>: To ensure your configuration remains up-to-date, disable this errand only when necessary.</p>
 
- * **Run Template Uploader**: 
+ * **Run Template Uploader**:
 	This errand is required to configure generic components that are included in a9s PostgreSQL for PCF with MPostgreSQLongoDB  configurations.
 	Disabling this errand may speed up the deployment of all tiles.
 
 	<p class="note"><strong>Note</strong>: To ensure your configuration remains up-to-date, disable this errand only when necessary.</p>
 
- * **Run Broker Registrar**: 
+ * **Run Broker Registrar**:
 	This errand registers the a9s PostgreSQL for PCF service broker
 	at the Elastic Runtime. This makes the service available in the Elastic Runtime
 	marketplace.
 
- * **Run Smoke Tests**: 
+ * **Run Smoke Tests**:
  This errand runs a series of basic tests against your a9s PostgreSQL for PCF
  installation to ensure that it is configured properly. Those tests may
- take awhile, probably over 30 minutes.
+ take a while, probably over 30 minutes.
 
 ### Pre-Delete Errands
 
- * **Delete all a9s PostgreSQL instances**: 
+ * **Delete all a9s PostgreSQL instances**:
 	This errand deletes all a9s PostgreSQL instances which were created with `cf create-service` by PCF end users.
 	<p class="note"><strong>Attention</strong>: This is an absolutly destructive task and can't be undone. All VMs of the service instances will be deleted irrecoverably. In the case a service instance is bound to an app or service keys are existing, the errand will fail.</p>
 
- * **Run Broker Deregistrar**: 
+ * **Run Broker Deregistrar**:
 	This will deregister the a9s PostgreSQL for PCF service broker in Elastic Runtime. This errand removes the a9s PostgreSQL service from the Elastic Runtime marketplace.
 
 ##<a id="configure-service-instance"></a> Configure Service Plans

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -45,8 +45,8 @@ Use **Errands** to configure the BOSH Errands used by a9s PostgreSQL for PCF. Fo
 ### Post-Deploy Errands
 
  * **Run BOSH Configurator**:
-	This errand configures **a9s BOSH for PCF** so that it can provision PostgreSQL
-	service instances. When enabled, this errand uploads the required releases in
+  This errand configures **a9s BOSH for PCF** so that it can provision PostgreSQL
+  service instances. When enabled, this errand uploads the required releases in
   the a9s BOSH Director. Disabling this errand may speed up the deployment of
   all tiles.
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -111,7 +111,7 @@ Follow the instructions below to unbind your service instance from all apps and 
 Run `cf service` to list your available services.
 
 <pre class="terminal">
-$ cf service
+$ cf services
 
 Getting services in org test / space test as admin...
 OK


### PR DESCRIPTION
This commits fixes a typo where the command "cf services" is actually run even though the text stipulates "cf service".

It also changes the explanation in the BOSH errand paragraph, since the stemcells have been removed from the tiles – but the task still uploads the releases on which it depends.