### PR TITLE
Create v1.1.0 release

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -109,11 +109,11 @@ The following table provides version and version-support information about a9s P
 <th>Version and support information</th>
  <tr>
  <td>Version</td>
- <td>v1.0.1</td>
+ <td>v1.1.0</td>
  </tr>
  <tr>
  <td>Release date</td>
- <td>April 20, 2017</td>
+ <td>June 1, 2017</td>
  </tr>
  <tr>
  <td>Compatible Ops Manager versions:</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,7 +5,18 @@ owner: Partners
 
 These are release notes for a9s PostgreSQL for Pivotal Cloud Foundry (PCF).
 
-## <a id="101"></a>v1.0.1
+## <a id="1-1-0"></a>v1.1.0
+
+**Release Date:** June 1, 2017
+
+* Added a Backup Manager that allows the creation of manual and automatic backups and manual recoveries.
+* Added a Service Guard that creates security groups for your instance.
+
+Known issues in this release:
+* Failed backups with empty configuration — The Backup Manager schedules backups
+even when its settings are left empty and these backups are displayed as “failed” in the Backup Manager API.
+
+## <a id="1-0-1"></a>v1.0.1
 
 **Release Date:** April 20, 2017
 
@@ -13,12 +24,7 @@ Features included in this release:
 
 * Added icon for Apps Manager
 
-Known issues in this release:
-
-* Failed backups with empty configuration — The Backup Manager schedules backups
-even when its settings are left empty and these backups are displayed as “failed” in the Backup Manager API.
-
-## <a id="100"></a>v1.0.0
+## <a id="1-0-0"></a>v1.0.0
 
 **Release Date:** March 14, 2017
 
@@ -27,7 +33,7 @@ even when its settings are left empty and these backups are displayed as “fail
 * Removed stemcell from tile to the a9s Bosh for PCF tile
 * Remove restriction to have three availability zones configured in the a9s Bosh for PCF
 
-## <a id="090"></a>v0.9.0
+## <a id="0-9-0"></a>v0.9.0
 
 **Release Date:** December 9, 2016
 


### PR DESCRIPTION
Hello,

we forgot to create a new version in the docs for the last feature we added (Service Guard, Backup Manager). This is now things done.

This new version corresponds to the tile tarball that my colleague @wolfoo2931 sent you.

Cheers,
Lucas
